### PR TITLE
Clarify cuDNN usage for autoencoder

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,19 @@ These baselines are implemented or re-used from prior work.
   After completing all five folds, the embedding that performs best on the test fold is selected.\
   To reduce the considerable runtime of the full 5-fold procedure, we employed a simpler 80\%/20\% train/validation split. The authors do not specify an exact embedding dimension; instead, they match it to the requirements of the prediction model. Following their observation that larger embeddings improve performance, we fix the embedding dimension to 128. \
   Due to the long runtime, we tested the autoencoder only at a window size of 3, following the original study’s finding that this setting yields the best predictive performance.
+- **cuDNN Setup (Autoencoder):**\
+  The autoencoder scripts run on **CPU by default**. To enable GPU training, set
+  the environment variable `AERAC_USE_GPU=true` and ensure cuDNN is installed.
+  We used cuDNN 8.9.6 with CUDA 12. Define `LD_LIBRARY_PATH` and
+  `LD_PRELOAD` so they point to your cuDNN installation, e.g.:
+
+  ```bash
+  export LD_LIBRARY_PATH=/path/to/cudnn/lib:$LD_LIBRARY_PATH
+  export LD_PRELOAD=/path/to/cudnn/lib/libcudnn.so.8
+  export AERAC_USE_GPU=true
+  ```
+
+  Without these variables, the scripts fall back to CPU execution.
 ---
 
 ## :test_tube: Intrinsic Evaluation

--- a/distances/activity_distances/gamallo_fernandez_2023_context_based_representations/src/embeddings_generator/aerac.py
+++ b/distances/activity_distances/gamallo_fernandez_2023_context_based_representations/src/embeddings_generator/aerac.py
@@ -4,6 +4,9 @@ import shutil
 import pandas as pd
 
 os.environ["TF_ENABLE_ONEDNN_OPTS"] = "0"
+
+# By default run on CPU. Set AERAC_USE_GPU=true to enable GPU training.
+USE_GPU = os.environ.get("AERAC_USE_GPU", "false").lower() == "true"
 import numpy as np
 import torch
 import torch.nn as nn
@@ -294,8 +297,8 @@ def run_AErac_model(eventlog: EventlogDataset, emb_size: int, win_size: int,
     early_stopping = EarlyStopping(monitor="val_loss", mode="min", patience=15)
 
     trainer = pl.Trainer(
-        accelerator='gpu',
-        devices=[2],
+        accelerator='gpu' if USE_GPU else 'cpu',
+        devices=1,
         max_epochs=Config.EPOCHS,
         deterministic=True,
         callbacks=[TQDMProgressBar(refresh_rate=200), checkpoint_callback, early_stopping]
@@ -368,7 +371,7 @@ def run_AErac_model(eventlog: EventlogDataset, emb_size: int, win_size: int,
     early_stopping = EarlyStopping(monitor="val_loss", mode="min", patience=15)
 
     trainer = pl.Trainer(
-        accelerator='gpu',
+        accelerator='gpu' if USE_GPU else 'cpu',
         devices=1,
         # Use a single GPU for deterministic training. If you wish to use multiple GPUs, consider strategy='dp'
         max_epochs=Config.EPOCHS,
@@ -698,9 +701,9 @@ def run_AErac_model(eventlog: EventlogDataset, emb_size: int, win_size: int,
     early_stopping = EarlyStopping(monitor="val_loss", mode="min", patience=15)
 
     trainer = pl.Trainer(
-        accelerator='gpu',
-        strategy="dp",
-        devices=1,  # Use a single GPU for deterministic training. If you wish to use multiple GPUs, consider strategy='dp'
+        accelerator='gpu' if USE_GPU else 'cpu',
+        strategy="dp" if USE_GPU else None,
+        devices=1,
         max_epochs=Config.EPOCHS,
         deterministic=True,
         callbacks=[TQDMProgressBar(refresh_rate=20), checkpoint_callback, early_stopping]


### PR DESCRIPTION
## Summary
- document how to use cuDNN with the autoencoder
- explain how to run without cuDNN
- make AERAC CPU by default with optional GPU via `AERAC_USE_GPU`

## Testing
- `python -m py_compile $(git ls-files '*.py')` *(fails: invalid syntax in repo)*

------
https://chatgpt.com/codex/tasks/task_e_6840696fcae88322897e262c681c84ae